### PR TITLE
Remove set() in list(set()) fix error of the unhashable

### DIFF
--- a/LGTV/__init__.py
+++ b/LGTV/__init__.py
@@ -142,7 +142,7 @@ def LGTVScan(first_only=False):
     if len(addresses) == 0:
         return []
 
-    return list(set(addresses))
+    return list(addresses)
 
 
 def resolveHost(hostname):


### PR DESCRIPTION
Error trying to run lgtv.py script with `python lgtv.py scan`:

Traceback (most recent all last):
File lgtv.py, line 58, in <module>
  results = LGTVScan()
File /tmp/LGWebOSRemove/LGTV/__init__.py, line 145, in LGTVScan
  return list(set(addresses))
TypeError: unhashable type: 'dict'