### PR TITLE
Tidied up packaging and updated for latest versions of dependencies

### DIFF
--- a/LGTV/__init__.py
+++ b/LGTV/__init__.py
@@ -119,7 +119,7 @@ def LGTVScan(first_only=False):
         try:
             response, address = sock.recvfrom(512)
             # print response
-            for line in response.split('\n'):
+            for line in response.decode().split('\n'):
                 if line.startswith("USN"):
                     uuid = re.findall(r'uuid:(.*?):', line)[0]
                 if line.startswith("DLNADeviceName"):
@@ -137,7 +137,7 @@ def LGTVScan(first_only=False):
             attempts -= 1
             continue
 
-        if re.search('LG', response):
+        if re.search('LG', response.decode()):
             if first_only:
                 sock.close()
                 return data
@@ -162,7 +162,7 @@ def resolveHost(hostname):
 
 def getMacAddress(address):
     pid = subprocess.Popen(["arp", "-n", address], stdout=subprocess.PIPE)
-    s = pid.communicate()[0]
+    s = pid.communicate()[0].decode()
     matches = re.search(r"(([a-f\d]{1,2}\:){5}[a-f\d]{1,2})", s)
     if not matches:
         return None

--- a/LGTV/__init__.py
+++ b/LGTV/__init__.py
@@ -1,13 +1,13 @@
 # -*- coding: utf-8 -*-
 from ws4py.client.threadedclient import WebSocketClient
 from types import FunctionType
-from wakeonlan import wol
 import json
 import socket
 import subprocess
 import re
 import os
 import sys
+import wakeonlan
 
 try:
     import urllib.parse
@@ -304,7 +304,7 @@ class LGTVClient(WebSocketClient):
     def on(self):
         if not self.__macAddress:
             print("Client must have been powered on and paired before power on works")
-        wol.send_magic_packet(self.__macAddress)
+        wakeonlan.send_magic_packet(self.__macAddress)
 
     def off(self):
         self.__send_command("", "request", "ssap://system/turnOff")

--- a/LGTV/main.py
+++ b/LGTV/main.py
@@ -52,7 +52,7 @@ def parseargs(command, argv):
         output[a] = argv[i]
     return output
 
-if __name__ == '__main__':
+def main():
     if len(sys.argv) < 2:
         usage("Too few arguments")
     elif sys.argv[1] == "scan":
@@ -93,3 +93,6 @@ if __name__ == '__main__':
             ws.run_forever()
         except KeyboardInterrupt:
             ws.close()
+
+if __name__ == '__main__':
+    main()

--- a/README.md
+++ b/README.md
@@ -58,15 +58,13 @@ All devices with firmware major version 4, product name "webOSTV 2.0"
 
 Requires wakeonlan, websocket for python and arp (in Debian/Ubuntu: apt-get install net-tools)
 
-There's a requirements.txt included
-
-    virtualenv venv
-    source venv/bin/activate
-    pip install -r requirements.txt
+    python -m venv lgtv-venv
+    source lgtv-venv/bin/activate
+    pip install git+https://github.com/klattimer/LGWebOSRemote
 
 ## Example usage
     # Scan/Authenticate
-    $ python lgtv.py scan 
+    $ lgtv scan 
     {
         "count": 1, 
         "list": [
@@ -78,16 +76,16 @@ There's a requirements.txt included
         ], 
         "result": "ok"
     }
-    $ python lgtv.py auth 192.168.1.31
+    $ lgtv auth 192.168.1.31
     
-    $ python lgtv.py on
-    $ python lgtv.py off
+    $ lgtv on
+    $ lgtv off
 
     # If you have the youtube plugin
-    $ python lgtv.py openYoutubeURL https://www.youtube.com/watch?v=dQw4w9WgXcQ
+    $ lgtv openYoutubeURL https://www.youtube.com/watch?v=dQw4w9WgXcQ
 
     # Otherwise, this works reasonably well
-    $ python lgtv.py openBrowserAt https://www.youtube.com/tv#/watch?v=dQw4w9WgXcQ
+    $ lgtv openBrowserAt https://www.youtube.com/tv#/watch?v=dQw4w9WgXcQ
 
 ## Caveats
 

--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ Command line webOS remote for LGTVs. This tool uses a connection via websockets 
   * UJ635V
   * UF776V
   * HU80KG.AEU (CineBeam 4K)
+  * OLED55B7
   * [please add more!]
 
 Tested with python 2.7 on mac/linux and works fine, your mileage may vary with windows, patches welcome.

--- a/install.sh
+++ b/install.sh
@@ -1,5 +1,0 @@
-#!/bin/bash
-virtualenv venv
-source venv/bin/activate
-pip install -r requirements.txt
-

--- a/lgtv.sh
+++ b/lgtv.sh
@@ -1,6 +1,0 @@
-#!/bin/bash
-SOURCE="$( readlink -f ${BASH_SOURCE[0]} )"
-DIR="$( cd "$( dirname "$SOURCE" )" && pwd )"
-cd $DIR
-source ./venv/bin/activate
-python lgtv.py "$@"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-wakeonlan==0.2.2
-git+https://github.com/Lawouach/WebSocket-for-Python.git#egg=ws4py
+wakeonlan==1.1.6
+ws4py==0.5.1

--- a/setup.py
+++ b/setup.py
@@ -37,7 +37,6 @@ setup(
     keywords=[
         'smarthome', 'smarttv', 'lg', 'tv', 'webos', 'remote'
     ],
-    dependency_links=['https://github.com/Lawouach/WebSocket-for-Python.git#egg=ws4py-0.4.3dev0'],
     install_requires=[
         'wakeonlan',
         'ws4py'

--- a/setup.py
+++ b/setup.py
@@ -42,6 +42,7 @@ setup(
         'wakeonlan',
         'ws4py'
     ],
+    entry_points={'console_scripts': ['lgtv = LGTV.main:main']},
     classifiers=[
         'Intended Audience :: Developers',
         'License :: OSI Approved :: MIT License',


### PR DESCRIPTION
Hi there. The main change here is the usage of `entry_points` in `setup.py` so that pip can install the script itself and it can just be run directly as `lgtv`. I removed `install.sh` and `lgtv.sh` since they're not really needed when the package is installable like that with pip.

I also made a couple of trivial changes to get it working with the current versions of Python and the dependencies (Python 3.7.3, wakeonlan 1.1.6, ws4py 0.5.1).

Thanks!