### PR TITLE
Remove strict device name checking 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ venv/
 *.egg-info
 __pycache__/
 /.pybuild/
+.DS_Store

--- a/LGTV/scan.py
+++ b/LGTV/scan.py
@@ -19,7 +19,7 @@ def LGTVScan():
     for i in range(attempts):
         sock.sendto(request, (b'239.255.255.250', 1900))
         uuid = None
-        model = None
+        tv_name = None
         address = None
         data = {}
         response, address = sock.recvfrom(512)
@@ -30,13 +30,13 @@ def LGTVScan():
                 except:
                     data['usn'] = line.strip().decode('utf-8')
                     continue
-            if line.startswith(b'DLNADeviceName'):
-                (junk, data) = line.split(b':')
-                data = data.strip().decode('utf-8')
-                model = re.findall(r'\[LG\] webOS TV (.*)', unquote(data))[0]
+            if line.startswith(b'DLNADeviceName.lge.com'):
+                tv_name = unquote(
+                    line.split(b':')[1].strip().decode('utf-8')
+                )
         data = {
             'uuid': uuid,
-            'model': model,
+            'tv_name': tv_name,
             'address': address[0]
         }
 


### PR DESCRIPTION
Same issue as [here](https://github.com/WebThingsIO/lg-tv-adapter/pull/7). If the DLNADeviceName header didn't start with "[LG] webOS TV" followed by the model then valid TVs would not be found. Instead checks the full header name matches `DLNADeviceName.lge.com` and saves its value as `tv_name` which can be used later for authentication and other commands.