### PR TITLE
Legacy Open-Youtube Commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,8 @@ All devices with firmware major version 4, product name "webOSTV 2.0"
 	lgtv MyTV openBrowserAt <url>
 	lgtv MyTV openYoutubeId <videoid>
 	lgtv MyTV openYoutubeURL <url>
+	lgtv MyTV openYoutubeLegacyId <videoid>
+	lgtv MyTV openYoutubeLegacyURL <url>
 	lgtv MyTV serialise
 	lgtv MyTV setInput <input_id>
 	lgtv MyTV setSoundOutput <tv_speaker|external_optical|external_arc|external_speaker|lineout|headphone|tv_external_speaker|tv_speaker_headphone|bt_soundbar>

--- a/debian/docs/lgtv.1
+++ b/debian/docs/lgtv.1
@@ -47,6 +47,8 @@ Control an LG webOS TV via the command line, works in linux, windows, macos
     openBrowserAt url
     openYoutubeId videoid
     openYoutubeURL url
+    openYoutubeLegacyId videoid
+    openYoutubeLegacyURL url
     setInput input_id
     setTVChannel channel
     setVolume level


### PR DESCRIPTION
Thank you for creating this awesome tool!

The 2017 models of LG OLED TVs, which are quite common and will probably stick around for a while, seem to be stuck at WebOS 3.x with no major upgrades. They are listed in the README as supported and there are probably more TV stuck at 3.x, then just the OLEDs.  Most commands seem to work without issues, but opening Youtube videos doesn't work. In this PR I added the commands openYoutubeLegacyId and openYoutubeLegacyURL, which work on WebOS 3.x. I also added the helper function get_youtube_id_from_url, since the videos are passed to Youtube only as IDs.

The openYoutubeLegacy commands should be tried, if the regular openYoutube command launches Youtube, but doesn't open the video. This PR fixes #33 .