### PR TITLE
fix leading zeroes bug in older versions of getmac

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 wakeonlan==1.1.6
 ws4py==0.5.1
 requests==2.22.0
-getmac==0.8.2
+getmac==0.9.2


### PR DESCRIPTION
Fixes: https://github.com/klattimer/LGWebOSRemote/issues/110

Upgrades `getmac` to fix a bug where leading zeroes are not parsed correctly. See:

- https://github.com/GhostofGoes/getmac/issues/82
- https://github.com/python/cpython/issues/101531