### PR TITLE
Add createAlert and closeAlert funtionallty

### DIFF
--- a/LGTV/remote.py
+++ b/LGTV/remote.py
@@ -192,6 +192,12 @@ class LGTVRemote(WebSocketClient):
 
     def notification(self, message, callback=None):
         self.__send_command("request", "ssap://system.notifications/createToast", {"message": message}, callback)
+	
+    def createAlert(self, message, button, callback=None):
+        self.__send_command("request", "ssap://system.notifications/createAlert", {"message": message, "buttons": [{"label": button}]}, callback)
+
+    def closeAlert(self, alertId, callback=None):
+        self.__send_command("request", "ssap://system.notifications/closeAlert", {'alertId': alertId}, callback)
 
 	# not working, why?
     #def notificationClose(self, toastId, callback=None):

--- a/README.md
+++ b/README.md
@@ -40,7 +40,9 @@ All devices with firmware major version 4, product name "webOSTV 2.0"
 	lgtv auth <host> MyTV
 	lgtv MyTV audioStatus
 	lgtv MyTV audioVolume
+	lgtv MyTV closeAlert <alertId>
 	lgtv MyTV closeApp <appid>
+	lgtv MyTV createAlert <message> <button>
 	lgtv MyTV execute <command>
 	lgtv MyTV getCursorSocket
 	lgtv MyTV getForegroundAppInfo

--- a/README.md
+++ b/README.md
@@ -25,11 +25,13 @@ Command line webOS remote for LGTVs. This tool uses a connection via websockets 
   * UJ701V
   * 60UJ6300-UA
   * OLED42C2 (ssl)
+  * OLED77GX
   * [please add more!]
 
 Tested with python 2.7 on mac/linux and works fine, your mileage may vary with windows, patches welcome.
 Tested with python 3.9 on Debian Unstable.
 Tested with python 3.10 on Windows 10/11
+Tested with 3.10 on WSL (Ubuntu 20.04)
 
 ### Likely supports
 

--- a/README.md
+++ b/README.md
@@ -152,8 +152,6 @@ You need to auth with the TV before being able to use the on command as it requi
 Implement the following features:
 
 	closeToast
-	createAlert
-	closeAlert
 	getSystemSettings
 
 ## Bugs


### PR DESCRIPTION
when executing createAlert, the response print to screen the alertId that can be later used for closeAlert