### PR TITLE
update remote.py for wol on different subnet

### DIFF
--- a/LGTV/remote.py
+++ b/LGTV/remote.py
@@ -180,9 +180,9 @@ class LGTVRemote(WebSocketClient):
     # Pragma Mark Supported commands
     #
     def on(self):
-        if not self.__macAddress:
+        if not (self.__macAddress) and not (self.__ip):
             print ("Client must have been powered on and paired before power on works")
-        send_magic_packet(self.__macAddress)
+        send_magic_packet(self.__macAddress, ip_address=self.__ip)
 
     def off(self):
         self.__send_command("request", "ssap://system/turnOff")


### PR DESCRIPTION
Hi klattimer, I've created this PR to address the bug where a TV maybe on a different subnet. I've added a second argument to the send_magic_packet function to pass in the ip address and I've also done a check before hand to check that the ip value isn't null.