### PR TITLE
Updated README to reflect the new expected argument structure

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ Command line webOS remote for LGTVs. This tool uses a connection via websockets 
   * OLED65B9PUA
   * OLED77CX9LA
   * OLED77GX
+  * OLED48C1 (ssl)
   * OLED42C2 (ssl)
   * OLED48C2 (ssl)
   * SK8500PLA
@@ -42,55 +43,55 @@ All devices with firmware major version 4, product name "webOSTV 2.0"
 ## Available Commands
 	lgtv scan
 	lgtv auth <host> MyTV
-	lgtv MyTV audioStatus
-	lgtv MyTV audioVolume
-	lgtv MyTV closeAlert <alertId>
-	lgtv MyTV closeApp <appid>
-	lgtv MyTV createAlert <message> <button>
-	lgtv MyTV execute <command>
-	lgtv MyTV getCursorSocket
-	lgtv MyTV getForegroundAppInfo
-	lgtv MyTV getPictureSettings
-	lgtv MyTV getPowerState
-	lgtv MyTV getSoundOutput
-	lgtv MyTV getSystemInfo
-	lgtv MyTV getTVChannel
-	lgtv MyTV input3DOff
-	lgtv MyTV input3DOn
-	lgtv MyTV inputChannelDown
-	lgtv MyTV inputChannelUp
-	lgtv MyTV inputMediaFastForward
-	lgtv MyTV inputMediaPause
-	lgtv MyTV inputMediaPlay
-	lgtv MyTV inputMediaRewind
-	lgtv MyTV inputMediaStop
-	lgtv MyTV listApps
-	lgtv MyTV listLaunchPoints
-	lgtv MyTV listChannels
-	lgtv MyTV listInputs
-	lgtv MyTV listServices
-	lgtv MyTV mute <true|false>
-	lgtv MyTV notification <message>
-	lgtv MyTV notificationWithIcon <message> <url>
-	lgtv MyTV off
-	lgtv MyTV on
-	lgtv MyTV openAppWithPayload <payload>
-	lgtv MyTV openBrowserAt <url>
-	lgtv MyTV openYoutubeId <videoid>
-	lgtv MyTV openYoutubeURL <url>
-	lgtv MyTV openYoutubeLegacyId <videoid>
-	lgtv MyTV openYoutubeLegacyURL <url>
-	lgtv MyTV serialise
-	lgtv MyTV setInput <input_id>
-	lgtv MyTV setSoundOutput <tv_speaker|external_optical|external_arc|external_speaker|lineout|headphone|tv_external_speaker|tv_speaker_headphone|bt_soundbar>
-	lgtv MyTV screenOff
-	lgtv MyTV screenOn
-	lgtv MyTV setTVChannel <channelId>
-	lgtv MyTV setVolume <level>
-	lgtv MyTV startApp <appid>
-	lgtv MyTV swInfo
-	lgtv MyTV volumeDown
-	lgtv MyTV volumeUp
+	lgtv --name MyTV --ssl audioStatus
+	lgtv --name MyTV --ssl audioVolume
+	lgtv --name MyTV --ssl closeAlert <alertId>
+	lgtv --name MyTV --ssl closeApp <appid>
+	lgtv --name MyTV --ssl createAlert <message> <button>
+	lgtv --name MyTV --ssl execute <command>
+	lgtv --name MyTV --ssl getCursorSocket
+	lgtv --name MyTV --ssl getForegroundAppInfo
+	lgtv --name MyTV --ssl getPictureSettings
+	lgtv --name MyTV --ssl getPowerState
+	lgtv --name MyTV --ssl getSoundOutput
+	lgtv --name MyTV --ssl getSystemInfo
+	lgtv --name MyTV --ssl getTVChannel
+	lgtv --name MyTV --ssl input3DOff
+	lgtv --name MyTV --ssl input3DOn
+	lgtv --name MyTV --ssl inputChannelDown
+	lgtv --name MyTV --ssl inputChannelUp
+	lgtv --name MyTV --ssl inputMediaFastForward
+	lgtv --name MyTV --ssl inputMediaPause
+	lgtv --name MyTV --ssl inputMediaPlay
+	lgtv --name MyTV --ssl inputMediaRewind
+	lgtv --name MyTV --ssl inputMediaStop
+	lgtv --name MyTV --ssl listApps
+	lgtv --name MyTV --ssl listLaunchPoints
+	lgtv --name MyTV --ssl listChannels
+	lgtv --name MyTV --ssl listInputs
+	lgtv --name MyTV --ssl listServices
+	lgtv --name MyTV --ssl mute <true|false>
+	lgtv --name MyTV --ssl notification <message>
+	lgtv --name MyTV --ssl notificationWithIcon <message> <url>
+	lgtv --name MyTV --ssl off
+	lgtv --name MyTV --ssl on
+	lgtv --name MyTV --ssl openAppWithPayload <payload>
+	lgtv --name MyTV --ssl openBrowserAt <url>
+	lgtv --name MyTV --ssl openYoutubeId <videoid>
+	lgtv --name MyTV --ssl openYoutubeURL <url>
+	lgtv --name MyTV --ssl openYoutubeLegacyId <videoid>
+	lgtv --name MyTV --ssl openYoutubeLegacyURL <url>
+	lgtv --name MyTV --ssl serialise
+	lgtv --name MyTV --ssl setInput <input_id>
+	lgtv --name MyTV --ssl setSoundOutput <tv_speaker|external_optical|external_arc|external_speaker|lineout|headphone|tv_external_speaker|tv_speaker_headphone|bt_soundbar>
+	lgtv --name MyTV --ssl screenOff
+	lgtv --name MyTV --ssl screenOn
+	lgtv --name MyTV --ssl setTVChannel <channelId>
+	lgtv --name MyTV --ssl setVolume <level>
+	lgtv --name MyTV --ssl startApp <appid>
+	lgtv --name MyTV --ssl swInfo
+	lgtv --name MyTV --ssl volumeDown
+	lgtv --name MyTV --ssl volumeUp
 
 ## Install
 
@@ -126,25 +127,25 @@ To install it system wide:
     # At this point the TV will request pairing, follow the instructions on screen
 
     # Commands are basically
-    #$ lgtv TVNAME COMMAND COMMAND ARGS
+    #$ lgtv --name TVNAME --ssl COMMAND COMMAND_ARGS
 
-    $ lgtv MyTV on
-    $ lgtv MyTV off
+    $ lgtv --name MyTV --ssl on
+    $ lgtv --name MyTV --ssl off
 
     # If you have the youtube plugin
-    $ lgtv MyTV openYoutubeURL https://www.youtube.com/watch?v=dQw4w9WgXcQ
+    $ lgtv --name MyTV --ssl openYoutubeURL https://www.youtube.com/watch?v=dQw4w9WgXcQ
 
     # Otherwise, this works reasonably well
-    $ lgtv MyTV openBrowserAt https://www.youtube.com/tv#/watch?v=dQw4w9WgXcQ
+    $ lgtv --name MyTV --ssl openBrowserAt https://www.youtube.com/tv#/watch?v=dQw4w9WgXcQ
 
 ## SSL
 
 Starting 25th of January 2023 LG has deprecated insecure ws connections, ssl is now required. Because of this, should you wish to use it on newer firmware devices you can append the argument "ssl" at the back. It connects to 3001 with wss. 
 ### Example
 ```
-$ lgtv auth 192.168.1.31 MyTV ssl 
-$ lgtv MyTV off ssl
-$ lgtv MyTV screenOff ssl
+$ lgtv auth 192.168.1.31 MyTV
+$ lgtv --name MyTV --ssl off
+$ lgtv --name MyTV --ssl screenOff
 ```
 
 ## Caveats


### PR DESCRIPTION
I was setting up a new computer/tv and found that I could `auth` with the tv but none of the commands would return any data. Dug in a bit deeper and found that this program [now expects arguments to be defined a bit differently](https://github.com/klattimer/LGWebOSRemote/pull/128).

This unsolicited PR updates README to reflect those changes. I opted for the syntax in the file thought I see that there are other options as well. 

(also added my C1 48 oled to the list)