### PR TITLE
Output an error message in case the `--name` argument is missing

### DIFF
--- a/LGTV/__init__.py
+++ b/LGTV/__init__.py
@@ -166,6 +166,9 @@ def main():
                     f.write(json.dumps(config))
                 print ("Wrote config file: " + filename)
             sys.exit(0)
+        else:
+            print("No TV selected or unknown command entered. Perhaps you are missing the -n/--name argument?")
+            sys.exit(1)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
This will help make it more obvious for people upgrading that the argument now need to be specified.

See for instance https://github.com/klattimer/LGWebOSRemote/issues/118#issuecomment-1819307552.