### PR TITLE
Short circuit the "on" command

### DIFF
--- a/LGTV/__init__.py
+++ b/LGTV/__init__.py
@@ -182,6 +182,12 @@ def main():
 
         try:
             ws = LGTVRemote(name, **config[name], ssl=args.ssl)
+
+            if args.command == "on":
+                # "on" is special, it doesn't use a websocket connection
+                ws.on()
+                return
+
             ws.connect()
             ws.execute(args.command, kwargs)
             ws.run_forever()


### PR DESCRIPTION
The "on" command is special since it doesn't make use of the websocket connection. It instead sends a wake-on-lan package. This means `ws.connect()` isn't needed for this and actually just slows down the command because it causes ws4py to try to establish a connection to a TV that is most likely off, considering the command being executed.

I did contemplate moving the "on" command out of the `LGTVRemote` class, but I thought this would be a smaller change. Another alternative would be to make `LGTVRemote.on` into a static method so it can be called without initialising `LGTVRemote`, but then we loose out on the config parsing done in `LGTVRemote.__init__`.