### PR TITLE
Drop Python 2.7 support

### DIFF
--- a/LGTV/__init__.py
+++ b/LGTV/__init__.py
@@ -1,11 +1,6 @@
 # -*- coding: utf-8 -*-
 from __future__ import print_function
-import platform
-isPython311AndAbove = (int(platform.python_version_tuple()[0]) == 3 and int(platform.python_version_tuple()[1]) >= 11) or int(platform.python_version_tuple()[0]) > 3
-if isPython311AndAbove:
-    from inspect import getfullargspec
-else:
-    from inspect import getargspec
+from inspect import getfullargspec
 
 import json
 import os
@@ -29,10 +24,7 @@ def get_commands():
     text = 'commands\n'
     commands = LGTVRemote.getCommands()
     for c in commands:
-        if isPython311AndAbove:
-            args = getfullargspec(LGTVRemote.__dict__[c])
-        else:
-            args = getargspec(LGTVRemote.__dict__[c])
+        args = getfullargspec(LGTVRemote.__dict__[c])
         line = ' ' + c
         if len(args.args) > 2:
             a = ' <' + '> <'.join(args.args[1:-1]) + '>'
@@ -42,10 +34,7 @@ def get_commands():
 
 
 def parseargs(command, argv):
-    if isPython311AndAbove:
-        args = getfullargspec(LGTVRemote.__dict__[command])
-    else:
-        args = getargspec(LGTVRemote.__dict__[command])
+    args = getfullargspec(LGTVRemote.__dict__[command])
     args = args.args[1:-1]
 
     if len(args) != len(argv):

--- a/README.md
+++ b/README.md
@@ -32,7 +32,6 @@ Command line webOS remote for LGTVs. This tool uses a connection via websockets 
   * UJ701V
   * [please add more!]
 
-Tested with python 2.7 on mac/linux and works fine, your mileage may vary with windows, patches welcome.
 Tested with python 3.9 on Debian Unstable.
 Tested with python 3.10 on Windows 10/11
 Tested with 3.10 on WSL (Ubuntu 20.04)

--- a/setup.py
+++ b/setup.py
@@ -37,8 +37,11 @@ setup(
     classifiers=[
         'Intended Audience :: Developers',
         'License :: OSI Approved :: MIT License',
-        'Programming Language :: Python :: 2.7',
-        'Programming Language :: Python :: 3.5',
+        'Programming Language :: Python :: 3.8',
+        'Programming Language :: Python :: 3.9',
+        'Programming Language :: Python :: 3.10',
+        'Programming Language :: Python :: 3.11',
+        'Programming Language :: Python :: 3.12',
         'Natural Language :: English',
     ],
 )


### PR DESCRIPTION
As far as I can tell, it hasn't worked the last four years following the changes in commit 0c4ad73. This means the check for which Python version that is used can be removed since `inspect.getfullargspec` has been available since Python 3.0.

This also updates the classifiers for the package to the currently maintained Python versions.