### PR TITLE
Add `--debug` flag to enable debug logging, otherwise default to info level

### DIFF
--- a/LGTV/__init__.py
+++ b/LGTV/__init__.py
@@ -107,9 +107,10 @@ def main():
     parser.add_argument('command')
     parser.add_argument('args', nargs='*')
     parser.add_argument('--ssl', action='store_true')
+    parser.add_argument('--debug', '-d', action='store_true', help='enable debug output')
     args = parser.parse_args()
 
-    logging.basicConfig(level=logging.DEBUG)
+    logging.basicConfig(level=logging.DEBUG if args.debug else logging.INFO)
 
     config = {}
 


### PR DESCRIPTION
Most users probably don't care about all the work to initiate connections and closing them again. This makes the output cleaner and could work as a good step towards refining the output from the utility.

Fixes #84.