### PR TITLE
Reimplement CLI using Click

### DIFF
--- a/LGTV/cli.py
+++ b/LGTV/cli.py
@@ -1,19 +1,30 @@
-import json
 import logging
 import sys
-from time import sleep
-from typing import Dict, Optional, Tuple
+from typing import List, Optional
 
 import click
 
-from LGTV.auth import LGTVAuth
-from LGTV.conf import read_config, write_config
-from LGTV.cursor import LGTVCursor
-from LGTV.remote import LGTVRemote
-from LGTV.scan import LGTVScan
+from LGTV import cli_static
+from LGTV.conf import read_config
 
 
-@click.group
+class CLI(click.MultiCommand):
+    def list_commands(self, ctx: click.Context) -> List[str]:
+        commands = []
+
+        for command in cli_static.__all__:
+            commands.append(command.replace("_", "-"))
+
+        return sorted(commands)
+
+    def get_command(self, ctx: click.Context, cmd_name: str) -> Optional[click.Command]:
+        fun_name = cmd_name.replace("-", "_")
+
+        if fun_name in cli_static.__all__:
+            return getattr(cli_static, fun_name)
+
+
+@click.group(cls=CLI)
 @click.option("-d", "--debug", is_flag=True, help="Enable debug output.")
 @click.option("-n", "--name", help="Name of the TV to manage.")
 @click.pass_context
@@ -45,76 +56,6 @@ def cli(ctx: click.Context, debug: bool = False, name: Optional[str] = None) -> 
         "tv_name": name,
         "tv_config": tv_config,
     }
-
-
-@cli.command
-def scan() -> None:
-    """Scan the local network for LG TVs."""
-    results = LGTVScan()
-
-    if len(results) > 0:
-        click.echo(json.dumps({"result": "ok", "count": len(results), "list": results}))
-        sys.exit(0)
-    else:
-        click.echo(json.dumps({"result": "failed", "count": len(results)}))
-        sys.exit(1)
-
-
-@cli.command
-@click.argument("host")
-@click.argument("name")
-@click.option("-s", "--ssl", is_flag=True, help="Connect to TV using SSL.")
-@click.pass_obj
-def auth(obj: Dict, host: str, name: str, ssl: bool = False) -> None:
-    """Connect to a new TV."""
-    if name.startswith("_"):
-        click.secho(
-            "TV names are not allowed to start with an underscore", fg="red", err=True
-        )
-        sys.exit(1)
-
-    ws = LGTVAuth(name, host, ssl=ssl)
-    ws.connect()
-    ws.run_forever()
-    sleep(1)
-    config = obj["full_config"]
-    config[name] = ws.serialise()
-    write_config(obj["config_path"], config)
-    click.echo(f"Wrote config file: {obj['config_path']}")
-
-
-@cli.command
-@click.argument("name")
-@click.pass_obj
-def set_default(obj: Dict, name: str) -> None:
-    """Change the default TV to interact with."""
-    config = obj["full_config"]
-    if name == "_default" or name not in config:
-        click.secho("TV not found in config", fg="red", err=True)
-        sys.exit(1)
-
-    config["_default"] = name
-    write_config(obj["config_path"], config)
-    click.echo(f"Default TV set to '{name}'")
-
-
-@cli.command
-@click.argument("buttons", nargs=-1)
-@click.option("-s", "--ssl", is_flag=True, help="Connect to TV using SSL.")
-@click.pass_obj
-def send_button(obj: Dict, buttons: Tuple[str], ssl: bool = False) -> None:
-    """Sends button presses from the remote."""
-    cursor = LGTVCursor(obj["tv_name"], **obj["tv_config"], ssl=ssl)
-    cursor.connect()
-    cursor.execute(buttons)
-
-
-@cli.command
-@click.pass_obj
-def on(obj: Dict) -> None:
-    """Turn on TV using Wake-on-LAN."""
-    remote = LGTVRemote(obj["tv_name"], **obj["tv_config"])
-    remote.on()
 
 
 if __name__ == "__main__":

--- a/LGTV/cli.py
+++ b/LGTV/cli.py
@@ -1,0 +1,100 @@
+import json
+import logging
+import sys
+from time import sleep
+from typing import Optional
+
+import click
+
+from LGTV.conf import read_config, write_config
+from LGTV.scan import LGTVScan
+from LGTV.auth import LGTVAuth
+
+
+@click.group
+@click.option("-d", "--debug", is_flag=True, help="Enable debug output.")
+@click.option("-n", "--name", help="Name of the TV to manage.")
+@click.pass_context
+def cli(ctx: click.Context, debug: bool = False, name: Optional[str] = None) -> None:
+    """Command line webOS remote for LG TVs."""
+    logging.basicConfig(level=logging.DEBUG if debug else logging.INFO)
+
+    config_path, full_config = read_config()
+    name = name or full_config.get("_default")
+
+    possible_tvs = list(full_config.keys())
+    try:
+        possible_tvs.remove("_default")
+    except ValueError:
+        pass
+
+    if name and name not in possible_tvs:
+        click.secho(
+            f"No entry with the name '{name}' was found in the configuration at {config_path}. Names found: {', '.join(possible_tvs)}",
+            fg="red",
+            err=True,
+        )
+        sys.exit(1)
+
+    tv_config = full_config.get(name, {})
+    ctx.obj = {
+        "config_path": config_path,
+        "full_config": full_config,
+        "tv_name": name,
+        "tv_config": tv_config,
+    }
+
+
+@cli.command
+def scan() -> None:
+    """Scan the local network for LG TVs."""
+    results = LGTVScan()
+
+    if len(results) > 0:
+        click.echo(json.dumps({"result": "ok", "count": len(results), "list": results}))
+        sys.exit(0)
+    else:
+        click.echo(json.dumps({"result": "failed", "count": len(results)}))
+        sys.exit(1)
+
+
+@cli.command
+@click.argument("host")
+@click.argument("name")
+@click.option("-s", "--ssl", is_flag=True, help="Connect to TV using SSL.")
+@click.pass_context
+def auth(ctx: click.Context, host: str, name: str, ssl: bool = False) -> None:
+    """Connect to a new TV."""
+    if name.startswith("_"):
+        click.secho(
+            "TV names are not allowed to start with an underscore", fg="red", err=True
+        )
+        sys.exit(1)
+
+    ws = LGTVAuth(name, host, ssl=ssl)
+    ws.connect()
+    ws.run_forever()
+    sleep(1)
+    config = ctx.obj["full_config"]
+    config[name] = ws.serialise()
+    write_config(ctx.obj["config_path"], config)
+    click.echo(f"Wrote config file: {ctx.obj['config_path']}")
+
+
+@cli.command
+@click.argument("name")
+@click.pass_context
+def set_default(ctx: click.Context, name: str) -> None:
+    """Change the default TV to interact with."""
+    config = ctx.obj["full_config"]
+    if name == "_default" or name not in config:
+        click.secho("TV not found in config", fg="red", err=True)
+        sys.exit(1)
+
+    config["_default"] = name
+    write_config(ctx.obj["config_path"], config)
+    click.echo(f"Default TV set to '{name}'")
+
+
+if __name__ == "__main__":
+    cli()

--- a/LGTV/cli.py
+++ b/LGTV/cli.py
@@ -2,13 +2,14 @@ import json
 import logging
 import sys
 from time import sleep
-from typing import Optional
+from typing import Optional, Tuple
 
 import click
 
-from LGTV.conf import read_config, write_config
-from LGTV.scan import LGTVScan
 from LGTV.auth import LGTVAuth
+from LGTV.conf import read_config, write_config
+from LGTV.cursor import LGTVCursor
+from LGTV.scan import LGTVScan
 
 
 @click.group
@@ -94,6 +95,17 @@ def set_default(ctx: click.Context, name: str) -> None:
     config["_default"] = name
     write_config(ctx.obj["config_path"], config)
     click.echo(f"Default TV set to '{name}'")
+
+
+@cli.command
+@click.argument("buttons", nargs=-1)
+@click.option("-s", "--ssl", is_flag=True, help="Connect to TV using SSL.")
+@click.pass_context
+def send_button(ctx: click.Context, buttons: Tuple[str], ssl: bool = False) -> None:
+    """Sends button presses from the remote."""
+    cursor = LGTVCursor(ctx.obj["tv_name"], **ctx.obj["tv_config"], ssl=ssl)
+    cursor.connect()
+    cursor.execute(buttons)
 
 
 if __name__ == "__main__":

--- a/LGTV/cli.py
+++ b/LGTV/cli.py
@@ -9,6 +9,7 @@ import click
 from LGTV.auth import LGTVAuth
 from LGTV.conf import read_config, write_config
 from LGTV.cursor import LGTVCursor
+from LGTV.remote import LGTVRemote
 from LGTV.scan import LGTVScan
 
 
@@ -106,6 +107,14 @@ def send_button(ctx: click.Context, buttons: Tuple[str], ssl: bool = False) -> N
     cursor = LGTVCursor(ctx.obj["tv_name"], **ctx.obj["tv_config"], ssl=ssl)
     cursor.connect()
     cursor.execute(buttons)
+
+
+@cli.command
+@click.pass_context
+def on(ctx: click.Context) -> None:
+    """Turn on TV using Wake-on-LAN."""
+    remote = LGTVRemote(ctx.obj["tv_name"], **ctx.obj["tv_config"])
+    remote.on()
 
 
 if __name__ == "__main__":

--- a/LGTV/cli.py
+++ b/LGTV/cli.py
@@ -8,7 +8,7 @@ from LGTV import cli_static
 from LGTV.conf import read_config
 
 
-class CLI(click.MultiCommand):
+class CLI(click.Group):
     def list_commands(self, ctx: click.Context) -> List[str]:
         commands = []
 
@@ -19,9 +19,7 @@ class CLI(click.MultiCommand):
 
     def get_command(self, ctx: click.Context, cmd_name: str) -> Optional[click.Command]:
         fun_name = cmd_name.replace("-", "_")
-
-        if fun_name in cli_static.__all__:
-            return getattr(cli_static, fun_name)
+        return getattr(cli_static, fun_name, None)
 
 
 @click.group(cls=CLI)

--- a/LGTV/cli.py
+++ b/LGTV/cli.py
@@ -2,7 +2,7 @@ import json
 import logging
 import sys
 from time import sleep
-from typing import Optional, Tuple
+from typing import Dict, Optional, Tuple
 
 import click
 
@@ -64,8 +64,8 @@ def scan() -> None:
 @click.argument("host")
 @click.argument("name")
 @click.option("-s", "--ssl", is_flag=True, help="Connect to TV using SSL.")
-@click.pass_context
-def auth(ctx: click.Context, host: str, name: str, ssl: bool = False) -> None:
+@click.pass_obj
+def auth(obj: Dict, host: str, name: str, ssl: bool = False) -> None:
     """Connect to a new TV."""
     if name.startswith("_"):
         click.secho(
@@ -77,43 +77,43 @@ def auth(ctx: click.Context, host: str, name: str, ssl: bool = False) -> None:
     ws.connect()
     ws.run_forever()
     sleep(1)
-    config = ctx.obj["full_config"]
+    config = obj["full_config"]
     config[name] = ws.serialise()
-    write_config(ctx.obj["config_path"], config)
-    click.echo(f"Wrote config file: {ctx.obj['config_path']}")
+    write_config(obj["config_path"], config)
+    click.echo(f"Wrote config file: {obj['config_path']}")
 
 
 @cli.command
 @click.argument("name")
-@click.pass_context
-def set_default(ctx: click.Context, name: str) -> None:
+@click.pass_obj
+def set_default(obj: Dict, name: str) -> None:
     """Change the default TV to interact with."""
-    config = ctx.obj["full_config"]
+    config = obj["full_config"]
     if name == "_default" or name not in config:
         click.secho("TV not found in config", fg="red", err=True)
         sys.exit(1)
 
     config["_default"] = name
-    write_config(ctx.obj["config_path"], config)
+    write_config(obj["config_path"], config)
     click.echo(f"Default TV set to '{name}'")
 
 
 @cli.command
 @click.argument("buttons", nargs=-1)
 @click.option("-s", "--ssl", is_flag=True, help="Connect to TV using SSL.")
-@click.pass_context
-def send_button(ctx: click.Context, buttons: Tuple[str], ssl: bool = False) -> None:
+@click.pass_obj
+def send_button(obj: Dict, buttons: Tuple[str], ssl: bool = False) -> None:
     """Sends button presses from the remote."""
-    cursor = LGTVCursor(ctx.obj["tv_name"], **ctx.obj["tv_config"], ssl=ssl)
+    cursor = LGTVCursor(obj["tv_name"], **obj["tv_config"], ssl=ssl)
     cursor.connect()
     cursor.execute(buttons)
 
 
 @cli.command
-@click.pass_context
-def on(ctx: click.Context) -> None:
+@click.pass_obj
+def on(obj: Dict) -> None:
     """Turn on TV using Wake-on-LAN."""
-    remote = LGTVRemote(ctx.obj["tv_name"], **ctx.obj["tv_config"])
+    remote = LGTVRemote(obj["tv_name"], **obj["tv_config"])
     remote.on()
 
 

--- a/LGTV/cli_static.py
+++ b/LGTV/cli_static.py
@@ -1,0 +1,85 @@
+import json
+import sys
+from time import sleep
+from typing import Dict, Tuple
+
+import click
+
+from LGTV.auth import LGTVAuth
+from LGTV.conf import write_config
+from LGTV.cursor import LGTVCursor
+from LGTV.remote import LGTVRemote
+from LGTV.scan import LGTVScan
+
+
+__all__ = ["scan", "auth", "set_default", "send_button", "on"]
+
+
+@click.command
+def scan() -> None:
+    """Scan the local network for LG TVs."""
+    results = LGTVScan()
+
+    if len(results) > 0:
+        click.echo(json.dumps({"result": "ok", "count": len(results), "list": results}))
+        sys.exit(0)
+    else:
+        click.echo(json.dumps({"result": "failed", "count": len(results)}))
+        sys.exit(1)
+
+
+@click.command
+@click.argument("host")
+@click.argument("name")
+@click.option("-s", "--ssl", is_flag=True, help="Connect to TV using SSL.")
+@click.pass_obj
+def auth(obj: Dict, host: str, name: str, ssl: bool = False) -> None:
+    """Connect to a new TV."""
+    if name.startswith("_"):
+        click.secho(
+            "TV names are not allowed to start with an underscore", fg="red", err=True
+        )
+        sys.exit(1)
+
+    ws = LGTVAuth(name, host, ssl=ssl)
+    ws.connect()
+    ws.run_forever()
+    sleep(1)
+    config = obj["full_config"]
+    config[name] = ws.serialise()
+    write_config(obj["config_path"], config)
+    click.echo(f"Wrote config file: {obj['config_path']}")
+
+
+@click.command
+@click.argument("name")
+@click.pass_obj
+def set_default(obj: Dict, name: str) -> None:
+    """Change the default TV to interact with."""
+    config = obj["full_config"]
+    if name == "_default" or name not in config:
+        click.secho("TV not found in config", fg="red", err=True)
+        sys.exit(1)
+
+    config["_default"] = name
+    write_config(obj["config_path"], config)
+    click.echo(f"Default TV set to '{name}'")
+
+
+@click.command
+@click.argument("buttons", nargs=-1)
+@click.option("-s", "--ssl", is_flag=True, help="Connect to TV using SSL.")
+@click.pass_obj
+def send_button(obj: Dict, buttons: Tuple[str], ssl: bool = False) -> None:
+    """Sends button presses from the remote."""
+    cursor = LGTVCursor(obj["tv_name"], **obj["tv_config"], ssl=ssl)
+    cursor.connect()
+    cursor.execute(buttons)
+
+
+@click.command
+@click.pass_obj
+def on(obj: Dict) -> None:
+    """Turn on TV using Wake-on-LAN."""
+    remote = LGTVRemote(obj["tv_name"], **obj["tv_config"])
+    remote.on()

--- a/LGTV/conf.py
+++ b/LGTV/conf.py
@@ -1,0 +1,41 @@
+import json
+import sys
+from pathlib import Path
+from typing import Dict, Tuple
+
+# TODO: Should this be replaced with click.get_app_dir()?
+search_paths = [
+    "/etc/lgtv/config.json",
+    "~/.lgtv/config.json",
+    "/opt/venvs/lgtv/config/config.json",
+]
+
+
+def read_config() -> Tuple[Path, Dict]:
+    # Check for existing config files
+    for path in map(Path, search_paths):
+        path = path.expanduser()
+        if path.exists():
+            with path.open() as fp:
+                return path, json.load(fp)
+
+    # Attempt to find place to write new config file
+    for path in map(Path, search_paths):
+        path = path.expanduser()
+
+        try:
+            path.parent.mkdir(parents=True, exist_ok=True)
+            return path, {}
+        except (FileExistsError, PermissionError):
+            pass
+
+    print(
+        "Cannot find suitable config path to write, create one in",
+        " or ".join(search_paths),
+    )
+    sys.exit(1)
+
+
+def write_config(path: Path, config: Dict) -> None:
+    with path.open("w") as fp:
+        json.dump(config, fp)

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ wakeonlan==1.1.6
 ws4py==0.5.1
 requests==2.31.0
 getmac==0.9.2
+click==8.1.7

--- a/setup.py
+++ b/setup.py
@@ -30,6 +30,7 @@ setup(
         'ws4py',
         'requests',
         'getmac',
+        'click>=8.1.0',
     ],
     data_files=[
         ('config', ['data/config.json'])


### PR DESCRIPTION
It has felt awkward every time I've tried to add a new command to the CLI, and the current help output doesn't show all available sub-commands because the commands are handled in different ways depending on if they are part of `LGTVRemote` or not.

To alleviate this situation, I tried to work on implementing the CLI using [Click](https://click.palletsprojects.com/) instead, and so far, I think it's been pretty good.

It currently implements the "auth", "scan", and "set-default" commands from the existing CLI, plus handles the config file centrally to make it easier for the sub-commands to work with.

The new code is also fully typed.

If this looks decent, I'll continue to work on getting the rest of the commands implemented. I'm thinking for the `LGTVRemote` and `LGTVCursor` commands that, it might be easier to implement them programmatically via a dictionary lookup rather than having separate functions for each of them since the difference mainly is which URI the call results in.