### PR TITLE
Remove ip_address from send_magic_packet

### DIFF
--- a/LGTV/remote.py
+++ b/LGTV/remote.py
@@ -182,7 +182,7 @@ class LGTVRemote(WebSocketClient):
     def on(self):
         if not (self.__macAddress) and not (self.__ip):
             print ("Client must have been powered on and paired before power on works")
-        send_magic_packet(self.__macAddress, ip_address=self.__ip)
+        send_magic_packet(self.__macAddress)
 
     def off(self):
         self.__send_command("request", "ssap://system/turnOff")


### PR DESCRIPTION
Without ip_address the wakeonlan magic packet will be sent to the default 255.255.255.255 (boardcast). This is required because during standby, the devices will not have their IP up and running.

Fixes: https://github.com/klattimer/LGWebOSRemote/issues/167