### PR TITLE
Added patch to fix ssl.wrap_socket error

### DIFF
--- a/LGTV/auth.py
+++ b/LGTV/auth.py
@@ -1,4 +1,5 @@
-from ws4py.client.threadedclient import WebSocketClient
+# from ws4py.client.threadedclient import WebSocketClient
+from .ws4py_patch import WebSocketClientPatch as WebSocketClient
 from getmac import get_mac_address
 import subprocess
 import socket

--- a/LGTV/cursor.py
+++ b/LGTV/cursor.py
@@ -4,7 +4,8 @@ import inspect
 from time import sleep
 
 from .remote import LGTVRemote
-from ws4py.client.threadedclient import WebSocketClient
+# from ws4py.client.threadedclient import WebSocketClient
+from .ws4py_patch import WebSocketClientPatch as WebSocketClient
 
 
 class LGTVCursor(WebSocketClient):

--- a/LGTV/remote.py
+++ b/LGTV/remote.py
@@ -1,4 +1,5 @@
-from ws4py.client.threadedclient import WebSocketClient
+# from ws4py.client.threadedclient import WebSocketClient
+from .ws4py_patch import WebSocketClientPatch as WebSocketClient
 from types import FunctionType
 from urllib.parse import parse_qs, urlparse
 from wakeonlan import send_magic_packet

--- a/LGTV/ws4py_patch.py
+++ b/LGTV/ws4py_patch.py
@@ -1,0 +1,55 @@
+from ws4py.client.threadedclient import WebSocketClient
+import ssl
+
+class WebSocketClientPatch(WebSocketClient):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+    
+    def connect(self):
+        """
+        Connects this websocket and starts the upgrade handshake
+        with the remote endpoint.
+        """
+        if self.scheme == "wss":
+            # default port is now 443; upgrade self.sender to send ssl
+            context = ssl.SSLContext(ssl.PROTOCOL_TLS_CLIENT)
+            if self.ssl_options.get('certfile', None):
+                context.load_cert_chain(self.ssl_options.get('certfile'), self.ssl_options.get('keyfile'))
+            # Prevent check_hostname requires server_hostname (ref #187)
+            if "cert_reqs" not in self.ssl_options:
+                context.check_hostname = False
+                context.verify_mode = ssl.CERT_NONE
+            self.sock = context.wrap_socket(self.sock)
+            self._is_secure = True
+
+        self.sock.connect(self.bind_addr)
+
+        self._write(self.handshake_request)
+
+        response = b''
+        doubleCLRF = b'\r\n\r\n'
+        while True:
+            bytes = self.sock.recv(128)
+            if not bytes:
+                break
+            response += bytes
+            if doubleCLRF in response:
+                break
+
+        if not response:
+            self.close_connection()
+            raise HandshakeError("Invalid response")
+
+        headers, _, body = response.partition(doubleCLRF)
+        response_line, _, headers = headers.partition(b'\r\n')
+
+        try:
+            self.process_response_line(response_line)
+            self.protocols, self.extensions = self.process_handshake_header(headers)
+        except HandshakeError:
+            self.close_connection()
+            raise
+
+        self.handshake_ok()
+        if body:
+            self.process(body)


### PR DESCRIPTION
Pushing a temporary fix for the issue https://github.com/klattimer/LGWebOSRemote/issues/165

Since the ssl library has been updated, the ws4py library started failing. The fix https://github.com/Lawouach/WebSocket-for-Python/commit/9ffee997a128ea9d7b09fb1dcf4aa280d25ebdc9 has already been merged but there is no new release of the ws4py library, and is not expected any sooner.

I am incorporating the fix as a patch in LGWebOSRemote. The patch is tested for scan, auth, listInputs and setInput  options only, and it works as a temporary fix.