### PR TITLE
Add setDeviceInfo command

### DIFF
--- a/LGTV/remote.py
+++ b/LGTV/remote.py
@@ -343,3 +343,7 @@ class LGTVRemote(WebSocketClient):
 
     def getPictureSettings(self, keys=["contrast", "backlight", "brightness", "color"]):
         self.__send_command("request", "ssap://settings/getSystemSettings", {"category": "picture", "keys": keys})
+
+    def setDeviceInfo(self, id, icon, label, callback=None):
+        self.__send_command("request", "luna://com.webos.service.eim/setDeviceInfo", {"id": id, "icon": icon, "label": label})
+

--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ A big thanks for the contributions over the years too, lots of people have made 
   * OLED48C1 (ssl)
   * OLED42C2 (ssl)
   * OLED48C2 (ssl)
+  * OLED83C4 (ssl)
   * SK8500PLA
   * SM9010PLA
   * UF776V
@@ -93,6 +94,9 @@ All devices with firmware major version 4, product name "webOSTV 2.0"
 	lgtv --name MyTV --ssl openYoutubeLegacyURL <url>
 	lgtv --name MyTV --ssl sendButton <button>
 	lgtv --name MyTV --ssl serialise
+	lgtv --name MyTV --ssl setDeviceInfo <id> <icon> <label>
+            # Example: lgtv --name MyTV --ssl setDeviceInfo HDMI_2 hdmi.png "My Input".
+            # Purpose: force TV to disable so-called "PC mode" for inputs where the attached device incorrectly or undesiredly signals itself as "PC", eg. Raspberry Pi with LibreELEC.
 	lgtv --name MyTV --ssl setInput <input_id>
 	lgtv --name MyTV --ssl setSoundOutput <tv_speaker|external_optical|external_arc|external_speaker|lineout|headphone|tv_external_speaker|tv_speaker_headphone|bt_soundbar>
 	lgtv --name MyTV --ssl screenOff


### PR DESCRIPTION
This patch adds a new command, setDeviceInfo, which allows forcing the TV to use a specific icon (which implies device type) and label for a specific HDMI input.

Background:

Some LG TVs such as the C4 will drive inputs in a so-called "PC mode" which means that most of the image processing features become inactive and unselectable. This happens when the device communicates itself as a PC or PC-like device (for example, media players like the Raspberry Pi with LibreELEC will do this). The main issue with this is that actually disabling PC mode is quite cumbersome and in some cases totally impossible:

* You have to go to the "Home" dashboard and click the vertical ellipsis (three dots) icon.
* Then select "Edit Inputs".
* Then click the icon of the input you want PC mode disabled for.
* Then select one of the non-PC icons.

And you have to repeat this every time the TV is cold booted.

Furthermore, doing this action is simply not possible when HDMI CEC is enabled for the input (this makes the input not appear at all in the list of editable inputs).

So, the command is added here which allows the "PC mode" to be disabled; without the cumbersome menu action and even when HDMI CEC is enabled. You can use this if you want to attach a PC or PC-like device but still want to take advantage of image processing.

Usage:

    lgtv --ssl setDeviceInfo <id> <icon> <label>

Usage example:

    lgtv --ssl setDeviceInfo HDMI_4 HDMI_4.png "My Kodi"

Input IDs and options for the "icon" argument can be listed with:

    lgtv --ssl listInputs

The "icon" argument only needs the base filename, not the full URL. The "label" argument has to be enclosed in quotes if it contains any spaces.