### PR TITLE
Respect the XDG Base Directory Specification

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 wakeonlan==1.1.6
-ws4py==0.5.1
+ws4py==0.6.0
 requests==2.32.4
 getmac==0.9.2


### PR DESCRIPTION
Use $XDG_CONFIG_HOME/lgtv/ as config directory.
If $XDG_CONFIG_HOME is not set then it defaults to $HOME/.config. The legacy config directory ~/.lgtv/ is kept for compatibility.

A few additional improvements in this commit:
- Do not create empty config directories
- use json.dump(object, file_handle) instead of file_handle.write(json.dumps(object))
- use json.load(file_handle) instead of json.loads(file_handle.read())
- Bump version of requirement ws4py to 0.6.0, fixing issue https://github.com/klattimer/LGWebOSRemote/issues/165